### PR TITLE
Changed comment in math.rs

### DIFF
--- a/packages/bignumber/src/math.rs
+++ b/packages/bignumber/src/math.rs
@@ -9,7 +9,7 @@ use bigint::U256;
 use cosmwasm_std::{Decimal, StdError, Uint128};
 
 /// A fixed-point decimal value with 18 fractional digits, i.e. Decimal256(1_000_000_000_000_000_000) == 1.0
-/// The greatest possible value that can be represented is 115792089237316195423570985008687907853269984665640564039457.584007913129639935 (which is (2^128 - 1) / 10^18)
+/// The greatest possible value that can be represented is 115792089237316195423570985008687907853269984665640564039457.584007913129639935 (which is (2^256 - 1) / 10^18)
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
 pub struct Decimal256(#[schemars(with = "String")] pub U256);
 


### PR DESCRIPTION
Little correction: Must be 2^256-1, not 2^128-1.
(2^256-1 is 115792089237316195423570985008687907853269984665640564039457584007913129639935)

## Summary of changes

Changed comment only.

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Added a relevant changelog entry to CHANGELOG.md

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
